### PR TITLE
Add g:projectionist_autocreate_alternative_file

### DIFF
--- a/autoload/projectionist.vim
+++ b/autoload/projectionist.vim
@@ -589,7 +589,11 @@ function! s:edit_command(cmd, count, ...) abort
         let i += 1
         call add(choices, i.' '.alt)
       endfor
-      let i = inputlist(choices)
+      if len(alternates) == 1 && g:projectionist_autocreate_alternative_file == 1
+        let i = 1
+      else
+        let i = inputlist(choices)
+      endif
       if i > 0
         let open = get(alternates, i-1, [])
       endif

--- a/doc/projectionist.txt
+++ b/doc/projectionist.txt
@@ -122,6 +122,15 @@ named etc/rbenv.d/ or one or more files matching the glob bin/rbenv-*.
 
 Note the use of VimScript |line-continuation|.
 
+                                                *g:projectionist_autocreate_alternative_file*
+When using :A or a variant to switch to an alternative file that does not yet
+exist, projectionist will by default ask if you wish the file to be created,
+requiring you to choose from a list of possible alternatives. To save you a
+few keystrokes in the common case of there being only one alternative, setting
+|g:projectionist_autocreate_alternative_file| to 1 will mean the prompt is
+skipped and the file automatically created. If there is more than one
+alternative available, the prompt will still be shown.
+
 COMMANDS                                        *projectionist-commands*
 
 In addition to any navigation commands provided by your projections (which

--- a/plugin/projectionist.vim
+++ b/plugin/projectionist.vim
@@ -12,6 +12,10 @@ if !exists('g:projectionist_heuristics')
   let g:projectionist_heuristics = {}
 endif
 
+if !exists('g:projectionist_autocreate_alternative_file')
+  let g:projectionist_autocreate_alternative_file = 0
+endif
+
 function! s:has(root, file) abort
   let file = matchstr(a:file, '[^!].*')
   if file =~# '\*'


### PR DESCRIPTION
Add new option which, if set, will skip the prompt for file creation
when switching to a non-existent file - if there is only one possible
alternative file. If there are multiple alternatives, the prompt is still shown.